### PR TITLE
Additional Launcher Info - HoNfigurator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,41 @@
 
 The only way to get real time support is from Project KONGOR's discord channel [#hosting](https://discord.com/channels/991034716360687637/1018466634408673340)
 
-### How to get started
+### Getting Started
+
+#### Pre-Requisites
 
 _Please read each step carefully_
 
 1. [Do it at your own risk](basics/risks.md)
 
-2. [System and infrastructure requirements](basics/system-and-infra.md)
+1. [System and infrastructure requirements](basics/system-and-infra.md)
 
-3. [Hosting from a vm server / vps - requirements](basics/vm-vps-server.md)
+1. [Hosting from a vm server / vps - requirements](basics/vm-vps-server.md)
 
-4. [Downloads](basics/downloads.md)
+#### Choosing a Launcher
+There are two main launchers for running HoN Servers:
+1. **COMPEL** - continue with this guide
+	- A simple tool to launch ``x`` number of HoN servers.
+	> Uses K2 Server Manager
+1. **[HoNfigurator](https://github.com/frankthetank001/honfigurator)** - click the link to view the HoNfigurator setup page
+	- A GUI based server launcher with some additional featuers
+	> Replaces the K2 Server Manager, provides notifications/alerting, and a server panel
 
-5. [Initial setup](basics/initial-setup.md)
+### Setting up COMPEL
+1. [Downloads](basics/downloads.md)
 
-6. [Port forwarding](basics/port-forwarding.md)
+1. [Initial setup](basics/initial-setup.md)
 
-7. [Testing server](basics/testing.md)
+1. [Port forwarding](basics/port-forwarding.md)
 
-8. [Deploy to public](basics/deploy-to-public.md)
+1. [Testing server](basics/testing.md)
 
-9. [Maintenance](basics/maintenance.md)
+1. [Deploy to public](basics/deploy-to-public.md)
 
-### Digging deeper - *comming soon*
+1. [Maintenance](basics/maintenance.md)
+
+### Digging deeper - *coming soon*
 
 Common error messages
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ There are two main launchers for running HoN Servers:
 
 1. [Maintenance](basics/maintenance.md)
 
+### Monitoring
+It is highly recommended that servers are monitored post configuration.
+
+Monitoring provides server log analysis, to determine how laggy the server is.
+
+In the future, it will become mandatory to run this monitoring, as only quality servers will be allowed to host in Ranked TMM server pool.
+
+[Set up server monitoring](https://github.com/frankthetank001/HoNfigurator/blob/main/docs/elasticsearch-monitoring-setup.md)
+
 ### Digging deeper - *coming soon*
 
 Common error messages

--- a/README.md
+++ b/README.md
@@ -38,14 +38,7 @@ There are two main launchers for running HoN Servers:
 
 1. [Maintenance](basics/maintenance.md)
 
-### Monitoring
-It is highly recommended that servers are monitored post configuration.
-
-Monitoring provides server log analysis, to determine how laggy the server is.
-
-In the future, it will become mandatory to run this monitoring, as only quality servers will be allowed to host in Ranked TMM server pool.
-
-[Set up server monitoring](https://github.com/frankthetank001/HoNfigurator/blob/main/docs/elasticsearch-monitoring-setup.md)
+1. [Monitoring](https://github.com/frankthetank001/HoNfigurator/blob/main/docs/elasticsearch-monitoring-setup.md)
 
 ### Digging deeper - *coming soon*
 


### PR DESCRIPTION
Added a secondary hosting option to use HoNfigurator.

Also linked to Elasticsearch monitoring setup guides, which supports both HoNfigurator and COMPEL.